### PR TITLE
MXC-CEC: Return writable for poll when no link status.

### DIFF
--- a/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
+++ b/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
@@ -584,7 +584,7 @@ static unsigned int hdmi_cec_poll(struct file *file, poll_table *wait)
 	poll_wait(file, &rx_queue, wait);
 	poll_wait(file, &tx_queue, wait);
 
-	if (priv->link_status == 1 &&
+	if (priv->link_status == 0 ||
 	    priv->tx_answer == CEC_TX_AVAIL)
 		mask |= POLLOUT | POLLWRNORM;
 


### PR DESCRIPTION
I was having an issue using the new driver when the HDMI cable wasn't connected where libcec would hang during init. The current libplatform has no timeout for the select loop during writes and would never return. I originally wanted to return POLLERR when there was no link but then I got hangs while reading since it's blocking and we don't fail reads if there is no link (didn't look to see if that's possible).

Minimal fix seems to notify of writable state while there is no link and then let the write fail.
